### PR TITLE
🧼 Cleanup the Github workflow

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,12 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
+    # Version of .NET is based off the value in global.json
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
 
     - name: Generate build number
       id: buildnumber

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "3.1.100",
+        "rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
Fixes #9 

NOTE: the `global.json` file is set to use the -latest- version of `3.1.x`. This way, we don't need to keep updating this file when new patches come out, for 3.1.x.

cc @phillip-haydon 