### PR TITLE
🔧 Fixed obsolete setting in GitHub workflow

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  VERSION: "1.0.${{ github.event.number }}"
 
 jobs:
   build:
@@ -13,20 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
 
     # Version of .NET is based off the value in global.json
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
 
-    - name: Generate build number
-      id: buildnumber
-      uses: einaregilsson/build-number@v2
-      with:
-        token: ${{secrets.github_token}}
-
     - name: Build with dotnet
-      run: dotnet build --configuration Release /p:AssemblyVersion=1.0.${{ steps.buildnumber.outputs.build_number }},Version=1.0.${{ steps.buildnumber.outputs.build_number }}
+      run: dotnet build --configuration Release -p:Version=${{ env.VERSION }}
 
     - name: Run unit tests
       run: dotnet test --configuration Release --no-build


### PR DESCRIPTION
Error was the old, original script was referencing an old (insecure) setting. Now fixed.

cc @phillip-haydon 